### PR TITLE
migrate to TypeScript 7.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,11 +29,12 @@
                 "@types/react-dom": "^19.1.9",
                 "@typescript-eslint/eslint-plugin": "^8.42.0",
                 "@typescript-eslint/parser": "^8.42.0",
+                "@typescript/native": "npm:typescript@^7.0.2",
                 "audit-ci": "^7.1.0",
                 "eslint": "^9.34.0",
                 "jest": "^30.3.0",
                 "prettier": "^3.6.2",
-                "typescript": "^7.0.2",
+                "typescript": "npm:@typescript/typescript6@^6.0.2",
                 "webpack": "^5.105.4"
             }
         },
@@ -2780,6 +2781,57 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@typescript/native": {
+            "name": "typescript",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+            "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc"
+            },
+            "engines": {
+                "node": ">=16.20.0"
+            },
+            "optionalDependencies": {
+                "@typescript/typescript-aix-ppc64": "7.0.2",
+                "@typescript/typescript-darwin-arm64": "7.0.2",
+                "@typescript/typescript-darwin-x64": "7.0.2",
+                "@typescript/typescript-freebsd-arm64": "7.0.2",
+                "@typescript/typescript-freebsd-x64": "7.0.2",
+                "@typescript/typescript-linux-arm": "7.0.2",
+                "@typescript/typescript-linux-arm64": "7.0.2",
+                "@typescript/typescript-linux-loong64": "7.0.2",
+                "@typescript/typescript-linux-mips64el": "7.0.2",
+                "@typescript/typescript-linux-ppc64": "7.0.2",
+                "@typescript/typescript-linux-riscv64": "7.0.2",
+                "@typescript/typescript-linux-s390x": "7.0.2",
+                "@typescript/typescript-linux-x64": "7.0.2",
+                "@typescript/typescript-netbsd-arm64": "7.0.2",
+                "@typescript/typescript-netbsd-x64": "7.0.2",
+                "@typescript/typescript-openbsd-arm64": "7.0.2",
+                "@typescript/typescript-openbsd-x64": "7.0.2",
+                "@typescript/typescript-sunos-x64": "7.0.2",
+                "@typescript/typescript-win32-arm64": "7.0.2",
+                "@typescript/typescript-win32-x64": "7.0.2"
+            }
+        },
+        "node_modules/@typescript/old": {
+            "name": "typescript",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
             }
         },
         "node_modules/@typescript/typescript-aix-ppc64": {
@@ -10099,38 +10151,17 @@
             }
         },
         "node_modules/typescript": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
-            "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+            "name": "@typescript/typescript6",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript6/-/typescript6-6.0.2.tgz",
+            "integrity": "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==",
             "dev": true,
             "license": "Apache-2.0",
+            "dependencies": {
+                "@typescript/old": "npm:typescript@^6"
+            },
             "bin": {
-                "tsc": "bin/tsc"
-            },
-            "engines": {
-                "node": ">=16.20.0"
-            },
-            "optionalDependencies": {
-                "@typescript/typescript-aix-ppc64": "7.0.2",
-                "@typescript/typescript-darwin-arm64": "7.0.2",
-                "@typescript/typescript-darwin-x64": "7.0.2",
-                "@typescript/typescript-freebsd-arm64": "7.0.2",
-                "@typescript/typescript-freebsd-x64": "7.0.2",
-                "@typescript/typescript-linux-arm": "7.0.2",
-                "@typescript/typescript-linux-arm64": "7.0.2",
-                "@typescript/typescript-linux-loong64": "7.0.2",
-                "@typescript/typescript-linux-mips64el": "7.0.2",
-                "@typescript/typescript-linux-ppc64": "7.0.2",
-                "@typescript/typescript-linux-riscv64": "7.0.2",
-                "@typescript/typescript-linux-s390x": "7.0.2",
-                "@typescript/typescript-linux-x64": "7.0.2",
-                "@typescript/typescript-netbsd-arm64": "7.0.2",
-                "@typescript/typescript-netbsd-x64": "7.0.2",
-                "@typescript/typescript-openbsd-arm64": "7.0.2",
-                "@typescript/typescript-openbsd-x64": "7.0.2",
-                "@typescript/typescript-sunos-x64": "7.0.2",
-                "@typescript/typescript-win32-arm64": "7.0.2",
-                "@typescript/typescript-win32-x64": "7.0.2"
+                "tsc6": "bin/tsc6"
             }
         },
         "node_modules/undici": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
                 "eslint": "^9.34.0",
                 "jest": "^30.3.0",
                 "prettier": "^3.6.2",
-                "typescript": "^5.9.2",
+                "typescript": "^7.0.2",
                 "webpack": "^5.105.4"
             }
         },
@@ -2780,6 +2780,346 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@typescript/typescript-aix-ppc64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+            "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-darwin-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+            "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-darwin-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+            "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-freebsd-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+            "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-freebsd-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+            "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-arm": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+            "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+            "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-loong64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+            "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-mips64el": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+            "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-ppc64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+            "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-riscv64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+            "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-s390x": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+            "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+            "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-netbsd-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+            "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-netbsd-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+            "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-openbsd-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+            "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-openbsd-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+            "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-sunos-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+            "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-win32-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+            "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-win32-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+            "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
             }
         },
         "node_modules/@ungap/structured-clone": {
@@ -9759,17 +10099,38 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-            "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+            "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
+                "tsc": "bin/tsc"
             },
             "engines": {
-                "node": ">=14.17"
+                "node": ">=16.20.0"
+            },
+            "optionalDependencies": {
+                "@typescript/typescript-aix-ppc64": "7.0.2",
+                "@typescript/typescript-darwin-arm64": "7.0.2",
+                "@typescript/typescript-darwin-x64": "7.0.2",
+                "@typescript/typescript-freebsd-arm64": "7.0.2",
+                "@typescript/typescript-freebsd-x64": "7.0.2",
+                "@typescript/typescript-linux-arm": "7.0.2",
+                "@typescript/typescript-linux-arm64": "7.0.2",
+                "@typescript/typescript-linux-loong64": "7.0.2",
+                "@typescript/typescript-linux-mips64el": "7.0.2",
+                "@typescript/typescript-linux-ppc64": "7.0.2",
+                "@typescript/typescript-linux-riscv64": "7.0.2",
+                "@typescript/typescript-linux-s390x": "7.0.2",
+                "@typescript/typescript-linux-x64": "7.0.2",
+                "@typescript/typescript-netbsd-arm64": "7.0.2",
+                "@typescript/typescript-netbsd-x64": "7.0.2",
+                "@typescript/typescript-openbsd-arm64": "7.0.2",
+                "@typescript/typescript-openbsd-x64": "7.0.2",
+                "@typescript/typescript-sunos-x64": "7.0.2",
+                "@typescript/typescript-win32-arm64": "7.0.2",
+                "@typescript/typescript-win32-x64": "7.0.2"
             }
         },
         "node_modules/undici": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
         "eslint": "^9.34.0",
         "jest": "^30.3.0",
         "prettier": "^3.6.2",
-        "typescript": "^7.0.2",
+        "@typescript/native": "npm:typescript@^7.0.2",
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
         "webpack": "^5.105.4"
     }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "eslint": "^9.34.0",
         "jest": "^30.3.0",
         "prettier": "^3.6.2",
-        "typescript": "^5.9.2",
+        "typescript": "^7.0.2",
         "webpack": "^5.105.4"
     }
 }

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,0 +1,4 @@
+declare module "*.css" {
+  const content: Record<string, string>;
+  export default content;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,9 +11,9 @@
         // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
         /* Language and Environment */
-        "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+        "target": "es2022" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
         "lib": [
-            "es2016",
+            "es2022",
             "dom",
             "dom.iterable"
         ] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
@@ -29,7 +29,8 @@
         // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
         /* Modules */
-        "module": "commonjs" /* Specify what module code is generated. */,
+        "module": "nodenext" /* Specify what module code is generated. */,
+        "moduleResolution": "nodenext" /* Specify how TypeScript looks up a file from a given module specifier. */,
         // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
         // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
         // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
Updates TypeScript from ^5.9.2 to ^7.0.2. Updates target to es2022, module to nodenext, adds CSS module declarations.